### PR TITLE
Update binary filename in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /go/src/github.com/oliver006/rethinkdb_exporter
 RUN apk add --update -t build-deps go git mercurial make \
     && apk add -u musl && rm -rf /var/cache/apk/* \
     && cd /go/src/github.com/oliver006/rethinkdb_exporter \
-    && go get && go build && cp redis_exporter /bin/rethinkdb_exporter \
+    && go get && go build && cp rethinkdb_exporter /bin/rethinkdb_exporter \
     && rm -rf /go && apk del --purge build-deps
 
 EXPOSE     9123


### PR DESCRIPTION
The docker build tries to copy over redis_exporter which does not exists. Should instead copy over rethinkdb_exporter.