### PR TITLE
add rethinkdb_up, allow hiding all table stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Name               | Description
 db.addr            | Address of one or more nodes of the cluster, comma separated.
 db.auth            | Auth key of the RethinkDB cluster.
 db.count-rows      | Count rows per table, turn off if you experience perf. issues with large tables
+db.table-stats     | Get stats for all tables.
 clustername        | Name of the cluster, if set it's added as a label to the metrics.
 namespace          | Namespace for the metrics, defaults to "rethinkdb".
 web.listen-address | Address to listen on for web interface and telemetry.
@@ -34,8 +35,8 @@ Metric names are `rethinkdb_cluster_[servers|server_errors|tables|replicas]_tota
 
 
 ### What does it look like?
-Example [PromDash](https://github.com/prometheus/promdash) screenshots:<br>
-![rethink_exporter_screen](https://cloud.githubusercontent.com/assets/1222339/7304973/88c2da14-e9c8-11e4-9f16-bf4de4dae63c.png)
+[Grafana](https://github.com/grafana) dashboard is available [here](https://grafana.com/dashboards/5043):<br>
+![rethink_exporter_dashboard](https://grafana.com/api/dashboards/5043/images/3108/image)
 
 
 

--- a/rethinkdb_exporter_test.go
+++ b/rethinkdb_exporter_test.go
@@ -121,7 +121,7 @@ func TestMetrics(t *testing.T) {
 
 	}
 
-	expectedCountMetrics := 52
+	expectedCountMetrics := 53
 	if countMetrics != expectedCountMetrics {
 		t.Errorf("Expected %d metrics, found %d", expectedCountMetrics, countMetrics)
 	}
@@ -142,7 +142,7 @@ func TestMetrics(t *testing.T) {
 		allDescr = append(allDescr, d)
 	}
 
-	wants := []string{"server_client_connections", "cluster_servers_total", "cluster_client_connections", "table_server_disk_read_bytes_per_sec", "table_server_disk_garbage_bytes"}
+	wants := []string{"server_client_connections", "cluster_servers_total", "cluster_client_connections", "table_server_disk_read_bytes_per_sec", "table_server_disk_garbage_bytes", "up"}
 	for _, w := range wants {
 		found := false
 		for _, d := range allDescr {
@@ -209,7 +209,7 @@ func TestMetricsNoRowCounting(t *testing.T) {
 
 	}
 
-	expectedCountMetrics := 50
+	expectedCountMetrics := 51
 	if countMetrics != expectedCountMetrics {
 		t.Errorf("Expected %d metrics, found %d", expectedCountMetrics, countMetrics)
 	}
@@ -259,8 +259,10 @@ func TestInvalidDB(t *testing.T) {
 	go e.scrape(scrapes)
 
 	neverTrue := false
-	for range scrapes {
-		neverTrue = true
+	for x := range scrapes {
+		if (x.Name != "up") {
+			neverTrue = true
+		}
 	}
 	if neverTrue {
 		t.Errorf("this shouldn't happen")


### PR DESCRIPTION
Hi, I'm proposing these changes:
-  `rethinkdb_up` metric - it is common way of exposing service's state ([see](https://prometheus.io/docs/instrumenting/writing_exporters/#failed-scrapes))
- `-db.table-stats` flag to allow hiding all table stats

I also updated readme and added current dashboard, since promdash is deprecated