### PR TITLE
feat: move to namstral/flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,16 +44,38 @@ $ helm install \
 
 Name               | Description
 -------------------|------------
-db.addr            | Address of one or more nodes of the cluster, comma separated.
-db.auth            | Auth key of the RethinkDB cluster (for versions < 2.3)
-db.user            | Username for RethinkDB connection (for versions >= 2.3) (must be `admin` if used; see below)
-db.pass            | Password for RethinkDB connection (for versions >= 2.3)
-db.count-rows      | Count rows per table, turn off if you experience perf. issues with large tables
-db.table-stats     | Get stats for all tables.
+db_addr            | Address of one or more nodes of the cluster, comma separated.
+db_auth            | Auth key of the RethinkDB cluster (for versions < 2.3)
+db_user            | Username for RethinkDB connection (for versions >= 2.3) (must be `admin` if used; see below)
+db_pass            | Password for RethinkDB connection (for versions >= 2.3)
+db_countrows       | Count rows per table, turn off if you experience perf. issues with large tables
+db_tablestats      | Get stats for all tables.
 clustername        | Name of the cluster, if set it's added as a label to the metrics.
 namespace          | Namespace for the metrics, defaults to "rethinkdb".
-web.listen-address | Address to listen on for web interface and telemetry, default `:9123`
-web.telemetry-path | Path under which to expose metrics.
+web_listenaddress  | Address to listen on for web interface and telemetry, default `:9123`
+web_telemetrypath  | Path under which to expose metrics.
+config             | Path to config file
+
+Flags can either be passed on the command line 
+```
+$ rethinkdb_exporter --db_user foo --db_pass bar
+```
+
+Or they can be passed as (uppercase) environment variables 
+```
+$ export DB_USER=foo 
+$ export DB_PASS=bar
+$ rethinkdb_exporter
+```
+
+Or in a config file
+```
+$ cat > rethinkdb_exporter.conf
+db_user foo
+db_pass bar
+
+$ rethinkdb_exporter --config rethinkdb_exporter.conf
+```
 
 
 ### What's exported?
@@ -74,7 +96,7 @@ Metric names are `rethinkdb_cluster_[servers|server_errors|tables|replicas]_tota
 
 ### v2.3+ Auth
 
-In v2.3 RethinkDB [moved](https://www.compose.com/articles/using-rethinkdb-2-3s-user-authentication/) to a username/password authentication system.  For compatibility with this use the `--db.user` and `--db.pass` options.
+In v2.3 RethinkDB [moved](https://www.compose.com/articles/using-rethinkdb-2-3s-user-authentication/) to a username/password authentication system.  For compatibility with this use the `--db_user` and `--db_pass` options.
 
 It would be good to use a dedicated read-only user for this but the RethinkDB [docs](https://rethinkdb.com/docs/system-stats/) say "the jobs table can only be accessed by the admin user account".  Thus you'll have to use `--db.user=admin`. 
 

--- a/helm/rethinkdb-exporter/templates/deployment.yaml
+++ b/helm/rethinkdb-exporter/templates/deployment.yaml
@@ -24,11 +24,11 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args: [
-            "--db.addr={{ .Values.rethinkdb_exporter.dbaddr }}",
-            "--db.auth={{ .Values.rethinkdb_exporter.dbauth }}",
-            "--db.user={{ .Values.rethinkdb_exporter.dbuser }}",
-            "--db.pass={{ .Values.rethinkdb_exporter.dbpass }}",
-            "--db.count-rows={{ .Values.rethinkdb_exporter.count_rows }}",
+            "--db_addr={{ .Values.rethinkdb_exporter.dbaddr }}",
+            "--db_auth={{ .Values.rethinkdb_exporter.dbauth }}",
+            "--db_user={{ .Values.rethinkdb_exporter.dbuser }}",
+            "--db_pass={{ .Values.rethinkdb_exporter.dbpass }}",
+            "--db_countrows={{ .Values.rethinkdb_exporter.count_rows }}",
             "--clustername={{ .Values.rethinkdb_exporter.clustername }}"
           ]
           ports:

--- a/rethinkdb_exporter.go
+++ b/rethinkdb_exporter.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net/http"
@@ -11,20 +10,22 @@ import (
 	"time"
 
 	r "github.com/GoRethink/gorethink"
+	"github.com/namsral/flag"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
-	addr          = flag.String("db.addr", "localhost:28015", "Address of one or more nodes of the cluster, comma separated")
-	auth          = flag.String("db.auth", "", "Auth key of the RethinkDB cluster")
-	user          = flag.String("db.user", "", "Auth user for 2.3+ RethinkDB cluster")
-	pass          = flag.String("db.pass", "", "Auth pass for 2.3+ RethinkDB cluster")
-	countRows     = flag.Bool("db.count-rows", true, "Count rows per table, turn off if you experience perf. issues with large tables")
-	getTableStats = flag.Bool("table-stats", true, "Get stats for all tables.")
+	addr          = flag.String("db_addr", "localhost:28015", "Address of one or more nodes of the cluster, comma separated")
+	auth          = flag.String("db_auth", "", "Auth key of the RethinkDB cluster")
+	user          = flag.String("db_user", "", "Auth user for 2.3+ RethinkDB cluster")
+	pass          = flag.String("db_pass", "", "Auth pass for 2.3+ RethinkDB cluster")
+	countRows     = flag.Bool("db_countrows", true, "Count rows per table, turn off if you experience perf. issues with large tables")
+	getTableStats = flag.Bool("db_tablestats", true, "Get stats for all tables.")
 	clusterName   = flag.String("clustername", "", "Cluster Name, added as label to metrics")
 	namespace     = flag.String("namespace", "rethinkdb", "Namespace for metrics")
-	listenAddress = flag.String("web.listen-address", ":9123", "Address to listen on for web interface and telemetry.")
-	metricPath    = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+	listenAddress = flag.String("web_listenaddress", ":9123", "Address to listen on for web interface and telemetry.")
+	metricPath    = flag.String("web_telemetrypath", "/metrics", "Path under which to expose metrics.")
+	configFile    = flag.String(flag.DefaultConfigFlagname, "", "Path to config file")
 )
 
 type Exporter struct {


### PR DESCRIPTION
Moves from the base "flag" package to [namstral/flag](https://github.com/namsral/flag). From the description of this package:

> Flag is a drop in replacement for Go's flag package with the addition to parse files and environment variables. If you support the twelve-factor app methodology, Flag complies with the third factor; "Store config in the environment".

This way we can supply DB passwords without these being available via `ps`. Added bonus is that it also provides simple config file support.

**Note:** [environment variables can only contain alphanumeric characters and underscores](https://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#index-name) so some of the original flags have had to be renamed to support this.