### PR TITLE
readme: fix link to grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Metric names are `rethinkdb_cluster_[servers|server_errors|tables|replicas]_tota
 
 
 ### What does it look like?
-[Grafana](https://github.com/grafana) dashboard is available [here](https://grafana.com/dashboards/5043):<br>
+[Grafana](https://github.com/grafana) dashboard is available [here](https://grafana.com/grafana/dashboards/5043-rethinkdb/):<br>
 ![rethink_exporter_dashboard](https://grafana.com/api/dashboards/5043/images/3108/image)
 
 


### PR DESCRIPTION
Current link gives me a 404. Thanks for all your work with this project!

![image](https://github.com/oliver006/rethinkdb_exporter/assets/12255914/533751be-77d9-4fd3-bfb5-e4f6922e0966)
